### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Additional benefit: Works with known hosts.
 
 ## Order is everything!
 
-It's necessary that `file` or `seconary` comes right after `autoipv6ptr`! This plugin always calls the next plugin and checks its return. It will only generate a PTR if a negative result comes back.
+It's necessary that `file` or `secondary` comes right after `autoipv6ptr`! This plugin always calls the next plugin and checks its return. It will only generate a PTR if a negative result comes back.
 
 ## Building a ready-to-use coredns binary using Docker
 


### PR DESCRIPTION
Fixed a typo in readme: seconary -> secondary

Spotted it when [forking](https://github.com/sniff122/coredns-autodomainip6) to make a "reverse" of this, domain to IP, work quite well in tandem together

Also not sure why there is a change in to the unknown record section, nothing had changed.